### PR TITLE
Fix 'gres_types' in slurm.conf.erb

### DIFF
--- a/templates/slurm.conf.erb
+++ b/templates/slurm.conf.erb
@@ -35,7 +35,7 @@ ExtSensorsType=<%= @ext_sensors_type %>
 ExtSensorsFreq=<%= @ext_sensors_freq %>
 FirstJobId=<%= @first_job_id %>
 MaxJobId=<%= @max_job_id %>
-<%= @gres_types.nil? ? '#GresTypes=' : ('GresTypes=' + @gres_types) %>
+<%= @gres_types.nil? ? '#GresTypes=' : ('GresTypes=' + @gres_types.join(',')) %>
 GroupUpdateForce=<%= @group_update_force %>
 JobCheckpointDir=<%= @job_checkpoint_dir %>
 JobContainerType=<%= @job_container_type %>


### PR DESCRIPTION
'gres_types' parameter is an 'Optional[Array[String]]', should contain
and Array of Strings or be 'undef'. However, template 'slurm.conf.erb'
does not reflect this and when gres_types is defined puppet crashes.

This update collects the string and applies a join separated by comma,
solving the mentioned problem.